### PR TITLE
[WIP] Add explicit NULL checks to most functions

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -538,6 +538,15 @@ yaslAllocSize
 The :c:`yaslAllocSize()` function returns the total allocated size of the
 specified yasl string, including the :c:`yastrhdr` and the full string buffer.
 
+yaslheader
+~~~~~~~~~~
+
+.. code:: c
+
+    struct yastrhdr * yaslheader(const yastr s)
+
+The :c:`yaslheader()` function returns a pointer to the :c:`yastrhdr` of a
+given :c:`yastr` string.
 
 yaslIncrLen
 ~~~~~~~~~~~

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -13,6 +13,12 @@ using yasl strings use is :c:`yastr` which is a :c:`char *` :c:`typedef`. Since
 it's just a typedef its use is not strictly necessary, but is recommended to
 make it clear that the given string is a yasl string.
 
+When a function that has the :c:`yastr` return type returns NULL it is
+signifying an error condition and all functions noted as possibly returning
+NULL must have their return value checked on each invocation. Passing a NULL
+pointer as an argument to a function expecting a :c:`yastr` is undefined and
+invalid.
+
 The second data structure is the following struct:
 
 .. code:: c
@@ -190,9 +196,12 @@ This function may :c:`realloc()` the string so all references to the original
 :c:`yastr` should be treated as invalid and should be replaced with the one
 returned by this function.
 
-This function may also return :c:`NULL` in case the :c:`realloc()` call failed,
-in which case the original :c:`yastr` references are still valid and should be
+This function may return :c:`NULL` in case the :c:`realloc()` call failed, in
+which case the original :c:`yastr` references are still valid and should be
 used.
+
+If the :c:`t` argument to the :c:`yaslcpylen()` function is a NULL pointer, no
+operation is performed and the function will return NULL.
 
 yaslcpy
 ~~~~~~~
@@ -210,10 +219,12 @@ This function may :c:`realloc()` the string so all references to the original
 :c:`yastr` should be treated as invalid and should be replaced with the one
 returned by the function.
 
-This function may also return :c:`NULL` in case the :c:`realloc()` call failed,
-in which case the original :c:`yastr` references are still valid and should be
+This function may return :c:`NULL` in case the :c:`realloc()` call failed, in
+which case the original :c:`yastr` references are still valid and should be
 used.
 
+If the :c:`t` argument to the :c:`yaslcpy()` function is a NULL pointer, no
+operation is performed and the function will return NULL.
 
 yasljoin
 ~~~~~~~~
@@ -225,6 +236,9 @@ yasljoin
 The :c:`yasljoin()` function joins an array of C strings using the specified
  C string separator, and returns the resulting string as a :c:`yastr`.
 
+If the :c:`argv` or :c:`sep` arguments to the :c:`yasljoin()` function are
+NULL pointers, no operation is performed and the function will return NULL.
+
 yasljoinyasl
 ~~~~~~~~~~~~
 
@@ -235,6 +249,9 @@ yasljoinyasl
 The :c:`yasljoinyasl()` function join an array of :c:`yastr` using the
 specified C string separator, and returns the resulting string as a new
 :c:`yastr`.
+
+If the :c:`sep` argument to the :c:`yasljoinyasl()` function is a NULL pointer,
+no operation is performed and the function will return NULL.
 
 yaslmapchars
 ~~~~~~~~~~~~
@@ -250,6 +267,9 @@ characters in the :c:`from` C string to the corresponding character in the
 Since this function just maps one set of characters to another set of
 characters it will never change the length of the string, so the existing
 references to the string will continue being valid.
+
+If the :c:`from` or :c:`to` arguments to the :c:`yaslmapchars()` function are
+NULL pointers, no operation is performed and the function will return NULL.
 
 yaslrange
 ~~~~~~~~~
@@ -284,7 +304,6 @@ yasltoupper
 The :c:`yasltoupper()` function takes a :c:`yastr` and runs the :c:`touppeupper()`
 function on each char of the string.
 
-
 yasltrim
 ~~~~~~~~
 
@@ -298,6 +317,9 @@ given :c:`yastr`, and returns a new :c:`yastr` without them.
 
 This function destructively modifies the string and all references to the old
 string will be invalid and should be updated to the returned one.
+
+If the :c:`cset` argument to the :c:`yasltrim()` function is a NULL pointer, no
+operation is performed and the function will return.
 
 yaslupdatelen
 ~~~~~~~~~~~~~
@@ -331,6 +353,9 @@ The opposite of this function is provided by the :c:`yaslcatrepr()` function.
 This function will return :c:`NULL` if the input contains unbalanced quoted or
 closed quotes followed by a non-space character.
 
+If the :c:`line` or :c:`argc` arguments to the :c:`yaslsplitargs()` function
+are NULL pointers, no operation is performed and the function will return NULL.
+
 yaslsplitlen
 ~~~~~~~~~~~~
 
@@ -347,6 +372,10 @@ and separators, so both can contain binary data.
 
 This function may return NULL on out of memory, or if a zero-length string or
 separator was given.
+
+If the :c:`s`, :c:`sep` or :c:`count` arguments to the :c:`yaslsplitlen()`
+function are NULL pointers, no operation is performed and the function will
+return NULL.
 
 Concatenation
 =============
@@ -369,6 +398,9 @@ The :c:`yaslcat()` function appends the given C string to the :c:`yastr s`
 This function may :c:`realloc()` the string so all references to the original
 :c:`yastr` should be treated as invalid and should be replaced with the one
 returned by the function.
+
+If the :c:`t` argument to the :c:`yaslcat()` function is a NULL pointer, no
+operation is performed and the function will return NULL.
 
 yaslcatyasl
 ~~~~~~~~~~~
@@ -401,6 +433,9 @@ This function may :c:`realloc()` the string so all references to the original
 :c:`yastr` should be treated as invalid and should be replaced with the one
 returned by this function.
 
+If the :c:`t` argument to the :c:`yaslcatlen()` function is a NULL pointer, no
+operation is performed and the function will return NULL.
+
 yaslcatrepr
 ~~~~~~~~~~~
 
@@ -415,6 +450,9 @@ turned into appropriate escape codes if existent, or a ``\x<hex>`` otherwise.
 This function may :c:`realloc()` the string so all references to the original
 :c:`yastr` should be treated as invalid and should be replaced with the one
 returned by this function.
+
+If the :c:`p` argument to the :c:`yaslcatrepr()` function is a NULL pointer, no
+operation is performed and the function will return NULL.
 
 yaslcatvprintf
 ~~~~~~~~~~~~~~
@@ -435,6 +473,8 @@ This function may :c:`realloc()` the string so all references to the original
 :c:`yastr` should be treated as invalid and should be replaced with the one
 returned by this function.
 
+If the :c:`fmt` argument to the :c:`yaslcatvprintf()` function is a NULL
+pointer, no operation is performed and the function will return NULL.
 
 yaslcatprintf
 ~~~~~~~~~~~~~
@@ -454,6 +494,9 @@ This function may :c:`realloc()` the string so all references to the original
 :c:`yastr` should be treated as invalid and should be replaced with the one
 returned by this function.
 
+If the :c:`fmt` argument to the :c:`yaslcatprintf()` function is a NULL
+pointer, no operation is performed and the function will return NULL.
+
 Freeing
 =======
 
@@ -467,8 +510,6 @@ yaslfree
     void yaslfree(yastr s)
 
 The :c:`yaslfree()` function frees a yasl string.
-
-If the :c:`s` argument is NULL no operation is performed.
 
 yaslfreesplitres
 ~~~~~~~~~~~~~~~~
@@ -496,6 +537,7 @@ yaslAllocSize
 
 The :c:`yaslAllocSize()` function returns the total allocated size of the
 specified yasl string, including the :c:`yastrhdr` and the full string buffer.
+
 
 yaslIncrLen
 ~~~~~~~~~~~
@@ -539,4 +581,3 @@ next concatenation operation will require an reallocation.
 This function will :c:`realloc()` the string so all references to the original
 :c:`yastr` should be treated as invalid and should be replaced with the one
 returned by this function.
-

--- a/src/yasl.c
+++ b/src/yasl.c
@@ -718,9 +718,9 @@ yaslcatprintf(yastr s, const char * fmt, ...) {
 /* Free a yasl string. No operation is performed if 's' is NULL. */
 void
 yaslfree(yastr s) {
-	if (!s) { return; }
-
-	free(yaslheader(s));
+	if (s) {
+		free(yaslheader(s));
+	}
 }
 
 /* Free the result returned by yaslsplitlen(), or do nothing if 'tokens' is NULL. */

--- a/src/yasl.c
+++ b/src/yasl.c
@@ -54,6 +54,8 @@ yaslnew(const void * init, size_t initlen) {
 /* Duplicate a yasl string. */
 yastr
 yasldup(const yastr s) {
+	if (!s) { return NULL; }
+
 	return yaslnew(s, yasllen(s));
 }
 
@@ -120,6 +122,8 @@ yaslcmp(const yastr s1, const yastr s2) {
  * number of bytes previously available. */
 void
 yaslclear(yastr s) {
+	if (!s) { return; }
+
 	struct yastrhdr * sh = yaslheader(s);
 	sh->free += sh->len;
 	sh->len = 0;
@@ -133,6 +137,8 @@ yaslclear(yastr s) {
  * is performed. */
 yastr
 yaslgrowzero(yastr s, size_t len) {
+	if (!s) { return NULL; }
+
 	struct yastrhdr * sh = yaslheader(s);
 	size_t totlen, curlen = sh->len;
 
@@ -153,6 +159,8 @@ yaslgrowzero(yastr s, size_t len) {
  * safe string pointed by 't' of length 'len' bytes. */
 yastr
 yaslcpylen(yastr s, const char * t, size_t len) {
+	if (!s || !t) { return NULL; }
+
 	struct yastrhdr * sh = yaslheader(s);
 	size_t totlen = sh->free + sh->len;
 
@@ -173,6 +181,8 @@ yaslcpylen(yastr s, const char * t, size_t len) {
  * of the string is obtained with strlen(). */
 yastr
 yaslcpy(yastr s, const char * t) {
+	if (!s || !t) { return NULL; }
+
 	return yaslcpylen(s, t, strlen(t));
 }
 
@@ -180,6 +190,8 @@ yaslcpy(yastr s, const char * t) {
  * Returns the result as a yasl string. */
 yastr
 yasljoin(char ** argv, int argc, char * sep, size_t seplen) {
+	if (!argv || !sep) { return NULL; }
+
 	yastr join = yaslempty();
 
 	for (int j = 0; j < argc; j++) {
@@ -192,6 +204,8 @@ yasljoin(char ** argv, int argc, char * sep, size_t seplen) {
 /* Like yasljoin, but joins an array of yasl strings. */
 yastr
 yasljoinyasl(yastr * argv, int argc, const char * sep, size_t seplen) {
+	if (!argv || !sep) { return NULL; }
+
 	yastr join = yaslempty();
 
 	for (int j = 0; j < argc; j++) {
@@ -212,6 +226,8 @@ yasljoinyasl(yastr * argv, int argc, const char * sep, size_t seplen) {
  * as the input pointer since no resize is needed. */
 yastr
 yaslmapchars(yastr s, const char * from, const char * to, size_t setlen) {
+	if (!s || !from || !to) { return NULL; }
+
 	for (size_t j = 0; j < yasllen(s); j++) {
 		for (size_t i = 0; i < setlen; i++) {
 			if (s[j] == from[i]) {
@@ -241,6 +257,8 @@ yaslmapchars(yastr s, const char * from, const char * to, size_t setlen) {
  */
 void
 yaslrange(yastr s, ptrdiff_t start, ptrdiff_t end) {
+	if (!s) { return; }
+
 	struct yastrhdr * sh = yaslheader(s);
 	size_t newlen, len = yasllen(s);
 
@@ -273,6 +291,8 @@ yaslrange(yastr s, ptrdiff_t start, ptrdiff_t end) {
 /* Apply tolower() to every character of the yasl string 's'. */
 void
 yasltolower(yastr s) {
+	if (!s) { return; }
+
 	for (size_t j = 0; j < yasllen(s); j++) {
 		s[j] = (char)tolower(s[j]);
 	}
@@ -281,6 +301,8 @@ yasltolower(yastr s) {
 /* Apply toupper() to every character of the yasl string 's'. */
 void
 yasltoupper(yastr s) {
+	if (!s) { return; }
+
 	for (size_t j = 0; j < yasllen(s); j++) {
 		s[j] = (char)toupper(s[j]);
 	}
@@ -302,6 +324,8 @@ yasltoupper(yastr s) {
  */
 void
 yasltrim(yastr s, const char * cset) {
+	if (!s || !cset) { return; }
+
 	struct yastrhdr * sh = yaslheader(s);
 	char * start, * end, * sp, * ep;
 	size_t len;
@@ -333,6 +357,8 @@ yasltrim(yastr s, const char * cset) {
  * remains 6 bytes. */
 void
 yaslupdatelen(yastr s) {
+	if (!s) { return; }
+
 	struct yastrhdr * sh = yaslheader(s);
 	size_t reallen = strlen(s);
 	sh->free += (sh->len - reallen);
@@ -360,6 +386,8 @@ yaslupdatelen(yastr s) {
  */
 yastr *
 yaslsplitargs(const char * line, int * argc) {
+	if (!line || !argc) { return NULL; }
+
 	const char * p = line;
 	char * current = NULL;
 	char ** vector = NULL;
@@ -494,6 +522,8 @@ err:
  */
 yastr *
 yaslsplitlen(const char * s, size_t len, const char * sep, size_t seplen, size_t * count) {
+	if (!s || !sep || !count) { return NULL; }
+
 	size_t elements = 0, slots = 5, start = 0;
 	yastr * tokens;
 
@@ -551,6 +581,8 @@ cleanup:
  * references must be substituted with the new pointer returned by the call. */
 yastr
 yaslcat(yastr s, const char * t) {
+	if (!s || !t) { return NULL; }
+
 	return yaslcatlen(s, t, strlen(t));
 }
 
@@ -560,6 +592,8 @@ yaslcat(yastr s, const char * t) {
  * references must be substituted with the new pointer returned by the call. */
 yastr
 yaslcatyasl(yastr s, const yastr t) {
+	if (!s || !t) { return NULL; }
+
 	return yaslcatlen(s, t, yasllen(t));
 }
 
@@ -570,6 +604,8 @@ yaslcatyasl(yastr s, const yastr t) {
  * references must be substituted with the new pointer returned by the call. */
 yastr
 yaslcatlen(yastr s, const void * t, size_t len) {
+	if (!s || !t) { return NULL; }
+
 	struct yastrhdr * sh;
 	size_t curlen = yasllen(s);
 
@@ -591,6 +627,8 @@ yaslcatlen(yastr s, const void * t, size_t len) {
  * references must be substituted with the new pointer returned by the call. */
 yastr
 yaslcatrepr(yastr s, const char * p, size_t len) {
+	if (!s || !p) { return NULL; }
+
 	s = yaslcatlen(s, "\"", 1);
 	while(len--) {
 		switch(*p) {
@@ -620,6 +658,8 @@ yaslcatrepr(yastr s, const char * p, size_t len) {
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 yastr
 yaslcatvprintf(yastr s, const char * fmt, va_list ap) {
+	if (!s || !fmt) { return NULL; }
+
 	va_list cpy;
 	char * buf, * t;
 	size_t buflen = 16;
@@ -662,6 +702,8 @@ yaslcatvprintf(yastr s, const char * fmt, va_list ap) {
  */
 yastr
 yaslcatprintf(yastr s, const char * fmt, ...) {
+	if (!s || !fmt) { return NULL; }
+
 	va_list ap;
 	char * t;
 	va_start(ap, fmt);
@@ -677,6 +719,7 @@ yaslcatprintf(yastr s, const char * fmt, ...) {
 void
 yaslfree(yastr s) {
 	if (!s) { return; }
+
 	free(yaslheader(s));
 }
 
@@ -684,6 +727,7 @@ yaslfree(yastr s) {
 void
 yaslfreesplitres(yastr * tokens, size_t count) {
 	if (!tokens) { return; }
+
 	while(count--) {
 		yaslfree(tokens[count]);
 	}
@@ -702,6 +746,8 @@ yaslfreesplitres(yastr * tokens, size_t count) {
  */
 size_t
 yaslAllocSize(yastr s) {
+	if (!s) { return 0; }
+
 	struct yastrhdr * sh = yaslheader(s);
 
 	return sizeof(*sh) + sh->len + sh->free + 1;
@@ -729,6 +775,8 @@ yaslAllocSize(yastr s) {
  */
 void
 yaslIncrLen(yastr s, size_t incr) {
+	if (!s) { return; }
+
 	struct yastrhdr * sh = yaslheader(s);
 
 	assert(sh->free >= incr);
@@ -745,6 +793,8 @@ yaslIncrLen(yastr s, size_t incr) {
  * by yasllen(), but only the free buffer space we have. */
 yastr
 yaslMakeRoomFor(yastr s, size_t addlen) {
+	if (!s) { return NULL; }
+
 	struct yastrhdr * sh, * newsh;
 	size_t free = yaslavail(s);
 	size_t len, newlen;
@@ -773,6 +823,8 @@ yaslMakeRoomFor(yastr s, size_t addlen) {
  * references must be substituted with the new pointer returned by the call. */
 yastr
 yaslRemoveFreeSpace(yastr s) {
+	if (!s) { return NULL; }
+
 	struct yastrhdr * sh = yaslheader(s);
 
 	struct yastrhdr * tmp = realloc(sh, sizeof(struct yastrhdr) + sh->len + 1);

--- a/src/yasl.h
+++ b/src/yasl.h
@@ -166,6 +166,8 @@ hex_digit_to_int(char c);
  */
 
 static inline struct yastrhdr *yaslheader(const yastr s) {
+	if (!s) { return NULL; }
+
 	/* The yastrhdr pointer has a different alignment than the original char
 	 * pointer, so cast it through a void pointer to silence the warning. */
 	return (void *)(s - (sizeof (struct yastrhdr)));
@@ -176,10 +178,14 @@ static inline yastr yaslauto(const char * s) {
 }
 
 static inline size_t yaslavail(const yastr s) {
+	if (!s) { return 0; }
+
 	return yaslheader(s)->free;
 }
 
 static inline size_t yasllen(const yastr s) {
+	if (!s) { return 0; }
+
 	return yaslheader(s)->len;
 }
 


### PR DESCRIPTION
The exception is yaslnew, which it is a valid usecase to pass a NULL
argument, and yaslcmp which runs memcmp on the arguments and passing it
a NULL yastr is undefined and invalid.

---

All docs have been updated to reflect NULL pointer arguments and return values.